### PR TITLE
todo task for gci and bug fix

### DIFF
--- a/modules/s3db/event.py
+++ b/modules/s3db/event.py
@@ -2282,7 +2282,7 @@ def event_notification_dispatcher(r, **attr):
         T = current.T
         msg = current.msg
         s3db = current.s3db
-
+        settings = current.deployment_settings
         ctable = s3db.pr_contact
         itable = s3db.event_incident
         etable = s3db.event_event


### PR DESCRIPTION
Link to the Todo : https://github.com/flavour/eden/blob/master/modules/s3db/deploy.py#L865
GCI task link : http://www.google-melange.com/gci/task/view/google/gci2014/5292591847309312

In this line : https://github.com/edengci/eden/blob/staging/modules/s3db/event.py#L2346 , settings = current.deployment_settings was missing .
So when we try to update an event details ( like : http://127.0.0.1:8000/eden/event/event/1/update)
when we click on the 'Send Notification tab' as ticket error said global name 'settings' is not defined.
So I added  "settings = current.deployment_settings" in L2285 , so that "send notification" tab can work properly.
