### PR TITLE
Add validator for sender field in CAP alerts

### DIFF
--- a/modules/s3db/cap.py
+++ b/modules/s3db/cap.py
@@ -295,8 +295,8 @@ class S3CAPModel(S3Model):
                            ),
                      Field("sender",
                            label = T("Sender"),
-                           default = self.generate_sender,
-                           # @todo: can not be empty in alerts (validator!)
+                           requires = IS_EMPTY_OR(IS_EMAIL())
+                           # @ToDo: require sender for actual alerts but not for templates
                            ),
                      s3_datetime("sent",
                                  default = "now",
@@ -942,19 +942,6 @@ class S3CAPModel(S3Model):
 
         return "%s-%s-%d%s%s" % \
                     (prefix, _time, next_id, ["", "-"][bool(suffix)], suffix)
-
-    # -------------------------------------------------------------------------
-    @staticmethod
-    def generate_sender():
-        """
-            Generate a sender for a new form
-        """
-        try:
-            user_id = current.auth.user.id
-        except AttributeError:
-            return ""
-
-        return "%s/%d" % (current.xml.domain, user_id)
 
     # -------------------------------------------------------------------------
     @staticmethod

--- a/modules/s3db/cr.py
+++ b/modules/s3db/cr.py
@@ -290,6 +290,7 @@ class S3ShelterModel(S3Model):
                            ),
                      Field("email", "string",
                            label = T("Email"),
+                           requires = IS_EMPTY_OR(IS_EMAIL())
                            ),
                      self.pr_person_id(label = T("Contact Person / Camp Owner")),
                      #Static field


### PR DESCRIPTION
- This validator checks for invalid characters [" ", ",", "&", "<"] and if the field is empty or not
- Also added a validator to the email field in create shelter
