### PR TITLE
Add filter for end date

### DIFF
--- a/modules/s3db/event.py
+++ b/modules/s3db/event.py
@@ -284,11 +284,15 @@ class S3EventModel(S3Model):
                                                 levels = levels,
                                                 label = T("Location"),
                                                 ),
-                               # @ToDo: Filter for any event which starts or ends within a date range
                                S3DateFilter("start_date",
-                                            label = None,
+                                            label=T("Start Date"),
                                             hide_time = True,
                                             input_labels = {"ge": "From", "le": "To"}
+                                            ),
+                               S3DateFilter("end_date",
+                                            label=T("End Date"),
+                                            hide_time=True,
+                                            input_labels={"ge": "From", "le": "To"}
                                             ),
                                ))
 
@@ -324,6 +328,7 @@ class S3EventModel(S3Model):
                                  "event_type_id$name",
                                  (T("Location"), "location.name"),
                                  "start_date",
+                                 "end_date",
                                  "exercise",
                                  "closed",
                                  "comments",


### PR DESCRIPTION
The todo asks for a filter for start_date and end_date between a certain range, although the current API does not allow this.

Therefore I added an end_date filter.

Melange task: http://www.google-melange.com/gci/task/view/google/gci2014/5811655824900096
