### PR TITLE
PDF codec tweaks

### DIFF
--- a/models/zzz_1st_run.py
+++ b/models/zzz_1st_run.py
@@ -210,6 +210,7 @@ if len(pop_list) > 0:
     s3.import_image = bi.import_image
     s3.import_remote_csv = bi.import_remote_csv
     s3.import_script = bi.import_script
+    s3.import_font = bi.import_font
 
     # Relax strict email-matching rule for import updates of person records
     email_required = settings.get_pr_import_update_requires_email()

--- a/modules/s3/s3codecs/pdf.py
+++ b/modules/s3/s3codecs/pdf.py
@@ -79,6 +79,7 @@ try:
     from reportlab.lib.colors import Color
     from reportlab.lib.pagesizes import A4, LETTER, landscape, portrait
     from reportlab.platypus.flowables import Flowable
+    from reportlab.pdfbase.ttfonts import TTFont
     reportLabImported = True
 except ImportError:
     reportLabImported = False
@@ -89,6 +90,26 @@ except ImportError:
 
 PDF_WIDTH = 0
 PDF_HEIGHT = 1
+
+font_set = current.deployment_settings.get_pdf_export_font()
+font_name = font_set[0]
+font_name_bold = font_set[1]
+
+try:
+    # Requires the font-file at /static/fonts/<font_name>.ttf
+    pdfmetrics.registerFont(TTFont(font_name, os.path.join(current.request.folder,
+                                                           "static",
+                                                           "fonts",
+                                                           font_name + ".ttf")))
+    # Requires the font-file at /static/fonts/<font_name_bold>.ttf
+    pdfmetrics.registerFont(TTFont(font_name_bold, os.path.join(current.request.folder,
+                                                                "static",
+                                                                "fonts",
+                                                                font_name_bold + ".ttf")))
+except:
+    # Using the default "Helvetica" and "Helvetica-bold"
+    font_name = "Helvetica"
+    font_name_bold = "Helvetica-bold"
 
 # =============================================================================
 class S3RL_PDF(S3Codec):
@@ -240,7 +261,7 @@ class S3RL_PDF(S3Codec):
 
         styleSheet = getSampleStyleSheet()
         style = styleSheet["Normal"]
-        style.fontName = "Helvetica"
+        style.fontName = font_name
         style.fontSize = 9
         if not body_flowable:
             body_flowable = [Paragraph("", style)]
@@ -1070,11 +1091,11 @@ class S3PDFTable(object):
                    (should work but need to test with a split table)
         """
 
-        style = [("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+        style = [("FONTNAME", (0, 0), (-1, -1), font_name),
                  ("FONTSIZE", (0, 0), (-1, -1), self.fontsize),
                  ("VALIGN", (0, 0), (-1, -1), "TOP"),
                  ("LINEBELOW", (0, 0), (endCol, 0), 1, Color(0, 0, 0)),
-                 ("FONTNAME", (0, 0), (endCol, 0), "Helvetica-Bold"),
+                 ("FONTNAME", (0, 0), (endCol, 0), font_name_bold),
                 ]
         sappend = style.append
         if colour_required:
@@ -1092,7 +1113,7 @@ class S3PDFTable(object):
                 if colour_required:
                     sappend(("BACKGROUND", (0, i), (endCol, i),
                              self.headerColour))
-                sappend(("FONTNAME", (0, i), (endCol, i), "Helvetica-Bold"))
+                sappend(("FONTNAME", (0, i), (endCol, i), font_name_bold))
                 sappend(("SPAN", (0, i), (endCol, i)))
                 sappend(("LEFTPADDING", (0, i), (endCol, i), 6 * level))
             elif i > 0:
@@ -1124,13 +1145,13 @@ class S3html2pdf():
         self.fontsize = 10
         styleSheet = getSampleStyleSheet()
         self.plainstyle = styleSheet["Normal"]
-        self.plainstyle.fontName = "Helvetica"
+        self.plainstyle.fontName = font_name
         self.plainstyle.fontSize = 9
         self.boldstyle = deepcopy(styleSheet["Normal"])
-        self.boldstyle.fontName = "Helvetica-Bold"
+        self.boldstyle.fontName = font_name_bold
         self.boldstyle.fontSize = 10
         self.titlestyle = deepcopy(styleSheet["Normal"])
-        self.titlestyle.fontName = "Helvetica-Bold"
+        self.titlestyle.fontName = font_name_bold
         self.titlestyle.fontSize = 16
         self.normalstyle = self.plainstyle
         # To add more pdf styles define the style above (just like the titlestyle)
@@ -1307,7 +1328,7 @@ class S3html2pdf():
 
         style = [("FONTSIZE", (0, 0), (-1, -1), self.fontsize),
                  ("VALIGN", (0, 0), (-1, -1), "TOP"),
-                 ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+                 ("FONTNAME", (0, 0), (-1, -1), font_name),
                  ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
                  ]
         content = []
@@ -1363,7 +1384,7 @@ class S3html2pdf():
                             rappend(result)
                             if isinstance(component, TH):
                                 sappend(("BACKGROUND", (colCnt, rowCnt), (colCnt, rowCnt), colors.lightgrey))
-                                sappend(("FONTNAME", (colCnt, rowCnt), (colCnt, rowCnt), "Helvetica-Bold"))
+                                sappend(("FONTNAME", (colCnt, rowCnt), (colCnt, rowCnt), font_name_bold))
                             if colspan > 1:
                                 for i in xrange(1, colspan):
                                     rappend("")

--- a/modules/s3/s3import.py
+++ b/modules/s3/s3import.py
@@ -37,6 +37,7 @@ __all__ = ("S3Importer",
 import cPickle
 import os
 import sys
+import requests
 import urllib2          # Needed for error handling on fetch
 import uuid
 from copy import deepcopy
@@ -3933,6 +3934,39 @@ class S3BulkImporter(object):
                 create_role(rulelist[0],
                             rulelist[1],
                             *acls[rulelist[0]])
+
+    # -------------------------------------------------------------------------
+    def import_font(self, url):
+        """
+            Import a Font File
+        """
+
+        filename = url.split("/")[-1]
+        extension = url.split(".")[-1]
+        response = requests.get(url)
+        if response.status_code == 200:
+            data = response.content
+
+            if extension == "zip":
+                import zipfile
+                zf = zipfile.ZipFile(StringIO(data))
+                for fn in zf.namelist():
+                    data = zf.read(fn)
+
+            if extension == "gz":
+                import tarfile
+                tf = tarfile.open(fileobj=StringIO(data))
+                for fn in tf.getnames():
+                    data = tf.extractFile(fn).read()
+
+            f = open(os.path.join(current.request.folder,
+                                  "static",
+                                  "fonts",
+                                  filename), "wb")
+            f.write(data)
+            f.close()
+        else:
+            current.log.error("Network Error, Unable to import font")
 
     # -------------------------------------------------------------------------
     def import_user(self, filename):

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -88,11 +88,46 @@ class S3Config(Storage):
                     #"tet": "",
                     "th": "%d/%m/%Y",
                     #"tl": "",
+                    "tr": "%d.%m.%Y",
                     #"ur": "",
                     "vi": "%d/%m/%Y",
                     "zh-cn": "%Y-%m-%d",
                     "zh-tw": "%Y/%m/%d",
                     }
+    # Custom fonts for each language
+    # fontset format -> [normal-version, bold-version]
+    font = {"ar": ["Helvetica", "Helvetica-Bold"],
+            "bs": ["Helvetica", "Helvetica-Bold"],
+            "de": ["Helvetica", "Helvetica-Bold"],
+            "el": ["Helvetica", "Helvetica-Bold"],
+            "es": ["Helvetica", "Helvetica-Bold"],
+            "en": ["Helvetica", "Helvetica-Bold"],
+            "fr": ["Helvetica", "Helvetica-Bold"],
+            "hr": ["Helvetica", "Helvetica-Bold"],
+            "it": ["Helvetica", "Helvetica-Bold"],
+            "ja": ["Helvetica", "Helvetica-Bold"],
+            "km": ["Helvetica", "Helvetica-Bold"],
+            "ko": ["Helvetica", "Helvetica-Bold"],
+            "mn": ["Helvetica", "Helvetica-Bold"],
+            "ne": ["Helvetica", "Helvetica-Bold"],
+            "prs": ["Helvetica", "Helvetica-Bold"],
+            "ps": ["Helvetica", "Helvetica-Bold"],
+            "pt": ["Helvetica", "Helvetica-Bold"],
+            "pt-br": ["Helvetica", "Helvetica-Bold"],
+            "ru": ["Helvetica", "Helvetica-Bold"],
+            "si": ["Helvetica", "Helvetica-Bold"],
+            "sr": ["Helvetica", "Helvetica-Bold"],
+            "sv": ["Helvetica", "Helvetica-Bold"],
+            "ta": ["Helvetica", "Helvetica-Bold"],
+            "tet": ["Helvetica", "Helvetica-Bold"],
+            "th": ["Helvetica", "Helvetica-Bold"],
+            "tr": ["unifont", "unifont"],
+            "tl": ["Helvetica", "Helvetica-Bold"],
+            "ur": ["Helvetica", "Helvetica-Bold"],
+            "vi": ["Helvetica", "Helvetica-Bold"],
+            "zh-cn": ["Helvetica", "Helvetica-Bold"],
+            "zh-tw": ["Helvetica", "Helvetica-Bold"],
+            }
 
     def __init__(self):
         self.auth = Storage()
@@ -1161,6 +1196,7 @@ class S3Config(Storage):
                                                        #("ta", "தமிழ்"),               # Tamil
                                                        #("th", "ภาษาไทย"),        # Thai
                                                        ("tl", "Tagalog"),
+                                                       ("tr", "Türkçe"),
                                                        ("ur", "اردو"),
                                                        ("vi", "Tiếng Việt"),
                                                        ]))
@@ -1310,6 +1346,10 @@ class S3Config(Storage):
                 excluded_fields_dict.get(resourcename, [])
 
         return excluded_fields
+
+    def get_pdf_export_font(self):
+        language = current.session.s3.language
+        return self.font.get(language)
 
     # -------------------------------------------------------------------------
     # UI Settings


### PR DESCRIPTION
This enables the use of Unifonts for pdf exports in Turkish language, There were some problems with a few Turkish characters not being shown, here is the discussion - 
https://groups.google.com/forum/#!msg/sahana-eden/X9JIJ0_d8Jo/mKW7e6Lpw2MJ
In order to test the pdf export in Turkish language, I would need the tr.py file.
