### PR TITLE
Small fix - No Label for 'Create Department' popup

### DIFF
--- a/modules/s3db/hrm.py
+++ b/modules/s3db/hrm.py
@@ -165,6 +165,7 @@ class S3HRModel(S3Model):
                                  ),
                      *s3_meta_fields())
 
+        tooltip = T("If you don't see the Department in the list, you can add a new one by clicking link 'Create Department' ")
         label_create = T("Create Department")
         crud_strings[tablename] = Storage(
             label_create = label_create,
@@ -193,7 +194,9 @@ class S3HRModel(S3Model):
             sortby = "name",
             comment = S3AddResourceLink(c="vol" if group == "volunteer" else "hrm",
                                         f="department",
-                                        label=label_create),
+                                        label=label_create,
+                                        title=label_create,
+                                        tooltip=tooltip),
             )
 
         configure("hrm_department",


### PR DESCRIPTION
How to generate the Error:
1. Open http://127.0.0.1:8000/eden/hrm/staff/summary
2. Click on add "Create Staff Member" button .
3. In the create form click on the "Create Department" link .
 The title of the popup box was not displaying

Added a tool tip also :)
